### PR TITLE
Fix fullscreen blackout issue with ::backdrop

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -72,6 +72,7 @@ input[type="number"] {
   transition: box-shadow 0.45s, border-color 0.45s ease-in-out;
 }
 
+
 input[type="number"]:focus {
   box-shadow: 0 0 5px #999999;
   border-color: #999999;
@@ -224,3 +225,6 @@ h3 {
 :-webkit-full-screen html{background-color: #dcdcdc}
 :-moz-full-screen html{background-color: #dcdcdc}
 :-ms-full-screen html{background-color: #dcdcdc}
+::backdrop {
+  background-color: #dcdcdc;
+}


### PR DESCRIPTION
The full-screen mode was completely dark. 
This was fixed with `::backdrop` pseudo-element.

https://caniuse.com/css-backdrop-filter
Shows it should not be an issue with the majority of the users.